### PR TITLE
docs: compose file needs cert folder to be defined for haproxy service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '2'
 services:
   haproxy:
     environment:
+      - CERT_FOLDER=/certs/
       - |
         DEFAULT_SSL_CERT=-----BEGIN RSA PRIVATE KEY-----
         MIIEpQIBAAKCAQEA3cp1UqMNJMWoHsFXWYGV080Rg8jLnhLMRFYHuF8ER56TOEi0


### PR DESCRIPTION
After some debugging I believe that defining the `CERT_FOLDER` is necessary to override the self-signed `DEFAULT_SSL_CERT`? HAProxy also needs to know where to look for the letsencrypt cert.

Addresses: https://github.com/ixc/letsencrypt-docker/issues/5